### PR TITLE
Add random file seeker for being able to use a random line of code

### DIFF
--- a/Sources/StreamReader/StreamReader.swift
+++ b/Sources/StreamReader/StreamReader.swift
@@ -130,10 +130,10 @@ open class StreamReader  {
     
     /// Put the filepointer to a random place
     open func seekRandom() {
-        buffer.removeAll(keepingCapacity: false)
         guard let fileOffset = allDelimeterOffsets?.randomElement() else {
             return
         }
+        buffer.removeAll(keepingCapacity: false)
         fileHandle!.seek(toFileOffset: fileOffset)
         atEof = false
     }


### PR DESCRIPTION
Abstract: 
When handling large files (>20MB), it is very unhandy to load each and every line into memory and get a random line. This is why the StreamReader could handle the randomization itself. It doesn't just safe lots of time that is only being used for reading the file but also safes lots of memory.

Improvement: 
Use strategy pattern for different seek/read handlings. (Backwards reading, random reading,..)
